### PR TITLE
Allow passing HTTP headers

### DIFF
--- a/pkg/beacon/bootstrap.go
+++ b/pkg/beacon/bootstrap.go
@@ -33,6 +33,7 @@ func (n *node) ensureClients(ctx context.Context) error {
 				ehttp.WithAddress(n.config.Addr),
 				ehttp.WithLogLevel(zerolog.Disabled),
 				ehttp.WithTimeout(timeout),
+				ehttp.WithExtraHeaders(n.config.Headers),
 			)
 			if err != nil {
 				failures++

--- a/pkg/beacon/config.go
+++ b/pkg/beacon/config.go
@@ -6,4 +6,6 @@ type Config struct {
 	Name string `yaml:"name"`
 	// Address is the address of the node.
 	Addr string `yaml:"addr"`
+	// Headers is the list of HTTP headers sent to the node.
+	Headers map[string]string `yaml:"headers"`
 }


### PR DESCRIPTION
Needed this to access beacon nodes hosted on ethpandaops.io