### PR TITLE
fix: Use string representation of ints in DepositSnapshotJSON

### DIFF
--- a/pkg/beacon/api/types/deposit_snapshot.go
+++ b/pkg/beacon/api/types/deposit_snapshot.go
@@ -21,9 +21,9 @@ type DepositSnapshot struct {
 type DepositSnapshotJSON struct {
 	Finalized            []string `json:"finalized"`
 	DepositRoot          string   `json:"deposit_root"`
-	DepositCount         uint64   `json:"deposit_count"`
+	DepositCount         uint64   `json:"deposit_count,string"`
 	ExecutionBlockHash   string   `json:"execution_block_hash"`
-	ExecutionBlockHeight uint64   `json:"execution_block_height"`
+	ExecutionBlockHeight uint64   `json:"execution_block_height,string"`
 }
 
 func (d *DepositSnapshot) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
Clients give (and expect) the integers deposit_count and execution_block_height to be represented as strings in the JSON. This mismatch that this commit fixes caused us to not actually store and serve the snapshots clients gave us.