### PR TITLE
feat(beacon): add default blob_sidecar topic

### DIFF
--- a/pkg/beacon/options.go
+++ b/pkg/beacon/options.go
@@ -92,6 +92,7 @@ func DefaultEnabledBeaconSubscriptionOptions() BeaconSubscriptionOptions {
 			topicHead,
 			topicVoluntaryExit,
 			topicContributionAndProof,
+			topicBlobSidecar,
 		},
 	}
 }


### PR DESCRIPTION
should wait until all CL's support this. If added and not supported will cause errors